### PR TITLE
Secure Build

### DIFF
--- a/oborpc/builder/_fastapi.py
+++ b/oborpc/builder/_fastapi.py
@@ -48,7 +48,7 @@ class FastAPIServerBuilder(ServerBuilder):
         self,
         instance: OBORBase,
         *,
-        prefix: str,
+        prefix: str = "",
         tags: Optional[List[Union[str, Enum]]] = None,
         dependencies: Optional[Sequence[params.Depends]] = None,
         default_response_class: Type[Response] = Default(JSONResponse),
@@ -65,6 +65,7 @@ class FastAPIServerBuilder(ServerBuilder):
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
         generate_unique_id_function: Callable[[APIRoute], str] = Default(generate_unique_id),
+        secure_build: bool = True,
     ): # pylint: disable=too-many-arguments,too-many-locals
         """
         build FastAPI API Router from oborpc instance
@@ -89,6 +90,6 @@ class FastAPIServerBuilder(ServerBuilder):
             generate_unique_id_function=generate_unique_id_function
         )
 
-        self.setup_server_rpc(instance, router)
+        self.setup_server_rpc(instance, router, secure_build)
 
         return router

--- a/oborpc/builder/_flask.py
+++ b/oborpc/builder/_flask.py
@@ -45,7 +45,8 @@ class FlaskServerBuilder(ServerBuilder):
         subdomain: Union[str, None] = None,
         url_defaults: Union[dict, None] = None,
         root_path: Union[str, None] = None,
-        cli_group: Union[str, None] = object()
+        cli_group: Union[str, None] = object(),
+        secure_build: bool = True,
     ): # pylint: disable=too-many-arguments
         """
         build Flask blueprint from oborpc instance
@@ -63,6 +64,6 @@ class FlaskServerBuilder(ServerBuilder):
             cli_group
         )
 
-        self.setup_server_rpc(instance, blueprint)
+        self.setup_server_rpc(instance, blueprint, secure_build)
 
         return blueprint

--- a/oborpc/builder/_server.py
+++ b/oborpc/builder/_server.py
@@ -38,22 +38,35 @@ class ServerBuilder:
         res = await method(instance, *args, **kwargs)
         return {"data": res}
 
-    def setup_server_rpc(self, instance: object, router):
+    def setup_server_rpc(self, instance: object, router, secure_build: bool = True):
         """
         Setup RPC Server
         """
         _class = instance.__class__
-        iterator_class = instance.__class__.__base__
         method_map = { # pylint: disable=unnecessary-comprehension
             name: method for (name, method) in inspect.getmembers(
                 _class, predicate=inspect.isfunction
             )
         }
 
+        iterator_class = instance.__class__.__base__
+        iterator_method_map = { # pylint: disable=unnecessary-comprehension
+            name: method for (name, method) in inspect.getmembers(
+                iterator_class, predicate=inspect.isfunction
+            )
+        }
+
         for (name, method) in inspect.getmembers(iterator_class, predicate=inspect.isfunction):
             if name not in iterator_class.__oborprocedures__:
                 continue
+
+            # validate
             method = method_map.get(name)
+            iterator_method = iterator_method_map.get(name)
+            if secure_build:
+                self.validate_implementation(name, method, _class, iterator_method, iterator_class)
+
+            # build router
             if inspect.iscoroutinefunction(method):
                 self.create_remote_responder_async(
                     instance, router, iterator_class.__name__,
@@ -64,3 +77,29 @@ class ServerBuilder:
                     instance, router, iterator_class.__name__,
                     name, method
                 )
+
+    def validate_implementation(
+        self,
+        method_name,
+        implementation_method,
+        implementation_class,
+        origin_method,
+        origin_class,
+    ):
+        # validate implementation: check overridden procedure
+        method_str = str(implementation_method)
+        method_origin = method_str[9:method_str.find(" at 0x")].split(".")[0].strip()
+        implementation_origin = str(implementation_class)[8:-2].split(".")[-1].strip()
+        err = f"Unable to build. Procedure `{implementation_origin}.{method_name}()` is not implemented"
+        assert method_origin == implementation_origin, err
+
+        # validate implementation: check procedure has the same callable type
+        is_implementation_coroutine = inspect.iscoroutinefunction(implementation_method)
+        is_origin_coroutine = inspect.iscoroutinefunction(origin_method)
+        callable_type = ["def", "async def"]
+        iterator_origin = str(origin_class)[8:-2].split(".")[-1].strip()
+        err = (
+            f"Unable to build. Procedure `{implementation_origin}.{method_name}()` is implemented as `{callable_type[int(is_implementation_coroutine)]}`. "
+            f"While the origin `{iterator_origin}.{method_name}()` is defined as `{callable_type[int(is_origin_coroutine)]}`."
+        )
+        assert is_implementation_coroutine == is_origin_coroutine, err

--- a/oborpc/decorator.py
+++ b/oborpc/decorator.py
@@ -2,9 +2,11 @@
 OBORPC Decorator
 """
 import inspect
-from typing import Callable
+from typing import Any, Callable, TypeVar
 
-def procedure(fun: Callable):
+DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., Any])
+
+def procedure(fun: Callable) -> DecoratedCallable:
     """
     Marks the method with this decorator to make it available
     for RPC within the class with direct inheritance with `OBORBase`.


### PR DESCRIPTION
Changes
- add assertion if the base class and implementation has different callable type (`def` or `async def`)
- add assertion if the base method is not implemented

Additionals
- add decorator `procedure` type hints with `DecoratedCallable`